### PR TITLE
Warm up server on load

### DIFF
--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -1,3 +1,4 @@
+fetch("https://scratchaddons-feedback.glitch.me/", {mode:'no-cors'})
 const version = new URL(location.href).searchParams.get("version");
 let sent = false;
 


### PR DESCRIPTION
This automatically warms up the server on page load, using fetch("https://scratchaddons-feedback.glitch.me/", {mode:'no-cors'})