### PR TITLE
fix logo in dark mode

### DIFF
--- a/site/assets/css/base.scss
+++ b/site/assets/css/base.scss
@@ -280,7 +280,9 @@ body.dark {
 
 	header {
 		img {
-			transform: scale(1.25);
+			height: 30px;
+			width: 30px;
+			transform: scale(1.75);
 		}
 	}
 
@@ -373,6 +375,8 @@ body.dark.extension-styled {
 
 	header {
 		img {
+			height: 30px;
+			width: 30px;
 			transform: scale(1.75);
 		}
 	}


### PR DESCRIPTION
the logo in dark mode is smaller in dark mode compared to light mode, this fixes this and makes the logo consistant.