### PR TITLE
Fix white border of cards in dark mode

### DIFF
--- a/site/assets/css/base.scss
+++ b/site/assets/css/base.scss
@@ -336,10 +336,7 @@ body.dark {
 	}
 
 	.card {
-		border-color: $dark-dp-16
-	}
-
-	.card-body {
+		border-color: $dark-dp-16;
 		background-color: $dark-dp-1;
 	}
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/51849865/112956204-7f9f1a80-9140-11eb-83d9-79f0c54de521.png)

Now:
![image](https://user-images.githubusercontent.com/51849865/112956212-8168de00-9140-11eb-8989-50fbc7f4d4f3.png)